### PR TITLE
fix: bump version to 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buddy-harmony",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "homepage": "https://Marthijs-Berfelo.github.io/buddy-harmony",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary
- Bumps `package.json` version to `0.10.0` to fix the failed release

## Test plan
- [ ] Verify CI passes
- [ ] Verify release workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)