### PR TITLE
chore: add dependency groups to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,49 @@ updates:
       # eslint-plugin-react does not support eslint 10 yet
       - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]
+    groups:
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+      typescript-eslint:
+        patterns:
+          - "@typescript-eslint/*"
+          - "typescript-eslint"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+      types-react:
+        patterns:
+          - "@types/react"
+          - "@types/react-dom"
+      testing-library:
+        patterns:
+          - "@testing-library/*"
+      fortawesome:
+        patterns:
+          - "@fortawesome/*"
+      i18next:
+        patterns:
+          - "i18next"
+          - "i18next-*"
+          - "react-i18next"
+      eslint:
+        patterns:
+          - "eslint"
+          - "@eslint/*"
+          - "eslint-*"
+          - "globals"
+      vite:
+        patterns:
+          - "vite"
+          - "@vitejs/*"
+      commitizen:
+        patterns:
+          - "commitizen"
+          - "cz-conventional-changelog"
+          - "cosmiconfig"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary

Groups related packages so Dependabot bumps them together in a single PR:

| Group | Packages |
|---|---|
| `vitest` | `vitest`, `@vitest/*` |
| `typescript-eslint` | `@typescript-eslint/*`, `typescript-eslint` |
| `react` | `react`, `react-dom` |
| `types-react` | `@types/react`, `@types/react-dom` |
| `testing-library` | `@testing-library/*` |
| `fortawesome` | `@fortawesome/*` |
| `i18next` | `i18next`, `i18next-*`, `react-i18next` |
| `eslint` | `eslint`, `@eslint/*`, `eslint-*`, `globals` |
| `vite` | `vite`, `@vitejs/*` |
| `commitizen` | `commitizen`, `cz-conventional-changelog`, `cosmiconfig` |

Fixes the `vitest`/`@vitest/coverage-v8` peer dependency conflict (PR #494) and prevents similar issues in the future.

## Test plan
- [ ] Verify dependabot.yml is valid
- [ ] Confirm Dependabot opens grouped PRs on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)